### PR TITLE
Add mlflow logging of metrics for each category

### DIFF
--- a/utils/callbacks.py
+++ b/utils/callbacks.py
@@ -28,6 +28,7 @@ class Callbacks:
             'on_val_image_end': [],
             'on_val_batch_end': [],
             'on_val_end': [],
+            'on_val_end_compute_metrics': [],
             'on_fit_epoch_end': [],  # fit = train + val
             'on_model_save': [],
             'on_train_end': [],

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -157,6 +157,8 @@ class Loggers():
         # Callback runs on train epoch end
         if self.wandb:
             self.wandb.current_epoch = epoch + 1
+        if self.mlflow:
+            self.mlflow.current_epoch = epoch + 1
 
     def on_val_image_end(self, pred, predn, path, names, im):
         # Callback runs on val image end
@@ -175,6 +177,16 @@ class Loggers():
                 self.clearml.log_debug_samples(files, title='Validation')
             if self.mlflow:
                 [self.mlflow.log_artifacts(f, "validation") for f in files if f.exists()]
+
+    def on_val_end_compute_metrics(self, names, ap50, ap, f1, p, r):
+        # log metrics for each class for every epoch
+        if self.mlflow:
+            for i in range(0, len(names)):
+                self.mlflow.log_metric(f"{names[i]}_mAP_0.5", ap50[i])
+                self.mlflow.log_metric(f"{names[i]}_mAP_0.5-0.95", ap[i])
+                self.mlflow.log_metric(f"{names[i]}_f1-score", f1[i])
+                self.mlflow.log_metric(f"{names[i]}_precision", p[i])
+                self.mlflow.log_metric(f"{names[i]}_recall", r[i])
 
     def on_fit_epoch_end(self, vals, epoch, best_fitness, fi):
         # Callback runs at the end of each fit (train+val) epoch

--- a/utils/loggers/mlflow/mlflow_utils.py
+++ b/utils/loggers/mlflow/mlflow_utils.py
@@ -56,6 +56,7 @@ class MlflowLogger:
         self.client = mlflow.tracking.MlflowClient()
         self.log_params(vars(opt))
         self.log_metrics(vars(opt), is_param=True)
+        self.current_epoch = {}
 
     @staticmethod
     def _flatten_params(params_dict, parent_key="", sep="/"):
@@ -127,6 +128,9 @@ class MlflowLogger:
             f"{prefix}{k.replace(':','-')}": float(v)
             for k, v in metrics.items() if (isinstance(v, float) or isinstance(v, int))}
         self.mlflow.log_metrics(metrics=metrics_dict, step=epoch)
+
+    def log_metric(self, key: str, value: float):
+        self.mlflow.log_metric(key, value, self.current_epoch)
 
     def finish_run(self) -> None:
         """Member function to end mlflow run.

--- a/val.py
+++ b/val.py
@@ -267,6 +267,9 @@ def run(
         tp, fp, p, r, f1, ap, ap_class = ap_per_class(*stats, plot=plots, save_dir=save_dir, names=names)
         ap50, ap = ap[:, 0], ap.mean(1)  # AP@0.5, AP@0.5:0.95
         mp, mr, map50, map = p.mean(), r.mean(), ap50.mean(), ap.mean()
+
+        callbacks.run('on_val_end_compute_metrics', names, ap50, ap, f1, p, r)
+
     nt = np.bincount(stats[3].astype(int), minlength=nc)  # number of targets per class
 
     # Print results

--- a/val.py
+++ b/val.py
@@ -277,7 +277,9 @@ def run(
         ap50, ap = ap[:, 0], ap.mean(1)  # AP@0.5, AP@0.5:0.95
         mp, mr, map50, map = p.mean(), r.mean(), ap50.mean(), ap.mean()
 
-        callbacks.run('on_val_end_compute_metrics', names, ap50, ap, f1, p, r)
+        available_names = [names[c] for c in ap_class]
+                   
+        callbacks.run('on_val_end_compute_metrics', available_names, ap50, ap, f1, p, r)
 
     nt = np.bincount(stats[3].astype(int), minlength=nc)  # number of targets per class
 


### PR DESCRIPTION
Thank you really a lot for your branch and pull request  [#8261](https://github.com/ultralytics/yolov5/pull/8261) about mlflow logging!!

I have added a small option about logging the metrics for each category/class for every epoch as I did not see it available at the moment. I use it in my tests in order to analyze the progress of the metrics of each class and compare the separate metrics between runs, as well.

Here is a simple visualization for a few classes and their mAP@5.0 progression during all the epochs, that can be produced:
![example](https://user-images.githubusercontent.com/8216410/188337202-05e7a398-264e-475f-b2f1-ea23a6fdaf9e.PNG)

I am looking forward for your review! Thank you again!

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->
